### PR TITLE
Moved default maven_download_dir under user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex
 maven_install_dir: /opt/maven
 
 # Directory to store files downloaded for Maven installation
-maven_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+maven_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex
 maven_install_dir: /opt/maven
 
 # Directory to store files downloaded for Maven installation
-maven_download_dir: "{{ x_ansible_download_dir | default('/tmp/ansible/data') }}"
+maven_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Changed default for `maven_download_dir` from `/tmp/ansible/data` to `~/.ansible/tmp/downloads`.

Enhancement: resolves #6