### PR TITLE
Removed "maven_" prefix from Maven facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Role Facts
 
 This role exports the following Ansible facts for use by other roles:
 
-* `ansible_local.java.general.maven_home`
+* `ansible_local.java.general.home`
 
     * e.g. `/opt/maven/apache-maven-3.3.9`
     
-* `ansible_local.java.general.maven_version`
+* `ansible_local.java.general.version`
 
     * e.g. `3.3.9`
 

--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,3 +1,3 @@
 [general]
-maven_version={{ maven_version }}
-maven_home={{ maven_install_dir }}/apache-maven-{{ maven_version }}
+version={{ maven_version }}
+home={{ maven_install_dir }}/apache-maven-{{ maven_version }}


### PR DESCRIPTION
Was unnecessarily verbose.

Enhancement: resolves #11