### PR TITLE
Added ansible_managed header to template file

### DIFF
--- a/templates/facts.j2
+++ b/templates/facts.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 [general]
 version={{ maven_version }}
 home={{ maven_install_dir }}/apache-maven-{{ maven_version }}


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.