### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -7,6 +7,3 @@ docker:
   - name: ansible-role-maven-01
     image: ubuntu
     image_version: '16.04'
-
-testinfra:
-  hosts: ansible-role-maven-01

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,3 +1,8 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_mvn_color(Command):
     assert '3.3.9' in Command.check_output('mvn --version')
 


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.