### PR TITLE
Fixed broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Related Roles
 You may find the following related roles useful:
 
 * [gantsign.java](https://galaxy.ansible.com/gantsign/java) for installing the Oracle JDK.
-* [gantsign.maven-color](https://galaxy.ansible.com/gantsign/java) for colorizing the Maven console output.
+* [gantsign.maven-color](https://galaxy.ansible.com/gantsign/maven-color) for colorizing the Maven console output.
 
     *  Installs the [Maven Color](https://github.com/jcgay/maven-color) extension for Maven authored by [Jean-Christophe Gay](https://github.com/jcgay).
 
-* [gantsign.maven-notifier](https://galaxy.ansible.com/gantsign/java) for providing a GUI notification when a build ends.
+* [gantsign.maven-notifier](https://galaxy.ansible.com/gantsign/maven-notifier) for providing a GUI notification when a build ends.
 
     *  Installs the [Maven Notifier](https://github.com/jcgay/maven-notifier) extension for Maven authored by [Jean-Christophe Gay](https://github.com/jcgay).
 


### PR DESCRIPTION
Fixed broken links to gantsign.maven-color and gantsign.maven-notifier.