### PR TITLE
Improved handling for YUM

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   yum:
     name: which
     state: present
-  when: "ansible_os_family == 'RedHat'"
+  when: ansible_pkg_mgr == 'yum'
 
 - name: create download directory
   file:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -30,7 +30,7 @@
       yum:
         name: java-1.8.0-openjdk-headless
         state: present
-      when: "ansible_os_family == 'RedHat'"
+      when: ansible_pkg_mgr == 'yum'
 
   roles:
     - role: ansible-role-maven


### PR DESCRIPTION
Now using `ansible_pkg_mgr` instead of `ansible_os_family` to decide whether to use yum.