### PR TITLE
Test Ansible version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 language: python
 python: '2.7'
 
+# Spin off separate builds for each of the following versions of Ansible
+env:
+- ANSIBLE_VERSION=2.0.1
+- ANSIBLE_VERSION=2.1.1
+
 # Require the standard build environment
 sudo: required
 
@@ -22,7 +27,7 @@ before_install:
 
 install:
   # Install Ansible
-  - pip install ansible
+  - pip install "ansible~=$ANSIBLE_VERSION"
 
   # Install Molecule
   - pip install 'molecule==1.11.1'


### PR DESCRIPTION
Added Ansible version to test Matrix.

Unfortunately Ansible 1.9 doesn't support docker so the minimum version that can be tested is 2.0.