### PR TITLE
Fixed default maven_download_dir home

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex
 maven_install_dir: /opt/maven
 
 # Directory to store files downloaded for Maven installation
-maven_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+maven_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"
 ```
 
 ### Supported Maven Versions

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,4 @@ maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex
 maven_install_dir: /opt/maven
 
 # Directory to store files downloaded for Maven installation
-maven_download_dir: "{{ x_ansible_download_dir | default('~/.ansible/tmp/downloads') }}"
+maven_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.ansible/tmp/downloads') }}"


### PR DESCRIPTION
Ensure the `maven_download_dir` defaults to the remote users home directory rather than the local user.