### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: load version vars
   with_first_found:
-    - "../vars/versions/{{ maven_version }}.yml"
+    - '../vars/versions/{{ maven_version }}.yml'
     - ../vars/versions/default.yml
-  include_vars: "{{ item }}"
+  include_vars: '{{ item }}'
 
 - name: assert version vars
   assert:
@@ -21,13 +21,13 @@
   file:
     state: directory
     mode: 'u=rwx,go=rx'
-    dest: "{{ maven_download_dir }}"
+    dest: '{{ maven_download_dir }}'
 
 - name: download Maven
   get_url:
-    url: "{{ maven_mirror }}/{{ maven_redis_filename }}"
-    dest: "{{ maven_download_dir }}/{{ maven_redis_filename }}"
-    sha256sum: "{{ maven_redis_sha256sum }}"
+    url: '{{ maven_mirror }}/{{ maven_redis_filename }}'
+    dest: '{{ maven_download_dir }}/{{ maven_redis_filename }}'
+    sha256sum: '{{ maven_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes
@@ -40,7 +40,7 @@
     owner: root
     group: root
     mode: 'u=rwx,go=rx'
-    dest: "{{ maven_install_dir }}"
+    dest: '{{ maven_install_dir }}'
 
 - name: install unarchive module dependencies (dnf)
   become: yes
@@ -55,21 +55,21 @@
 - name: install Maven
   become: yes
   unarchive:
-    src: "{{ maven_download_dir }}/{{ maven_redis_filename }}"
-    dest: "{{ maven_install_dir }}"
+    src: '{{ maven_download_dir }}/{{ maven_redis_filename }}'
+    dest: '{{ maven_install_dir }}'
     copy: no
     owner: root
     group: root
     mode: 'go-w'
-    creates: "{{ maven_install_dir }}/apache-maven-{{ maven_version }}"
+    creates: '{{ maven_install_dir }}/apache-maven-{{ maven_version }}'
 
 - name: install mvn link
   become: yes
   file:
     state: link
     force: yes
-    src: "{{ maven_install_dir }}/apache-maven-{{ maven_version }}/bin/mvn"
-    dest: "/usr/local/bin/mvn"
+    src: '{{ maven_install_dir }}/apache-maven-{{ maven_version }}/bin/mvn'
+    dest: '/usr/local/bin/mvn'
     owner: root
     group: root
     mode: 'u=rwx,go=rx'
@@ -79,8 +79,8 @@
   file:
     state: link
     force: yes
-    src: "{{ maven_install_dir }}/apache-maven-{{ maven_version }}/bin/mvnDebug"
-    dest: "/usr/local/bin/mvnDebug"
+    src: '{{ maven_install_dir }}/apache-maven-{{ maven_version }}/bin/mvnDebug'
+    dest: '/usr/local/bin/mvnDebug'
     owner: root
     group: root
     mode: 'u=rwx,go=rx'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 # Filename of Maven redistributable package
-maven_redis_filename: "apache-maven-{{ maven_version }}-bin.tar.gz"
+maven_redis_filename: 'apache-maven-{{ maven_version }}-bin.tar.gz'


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.