### PR TITLE
Temporally disable OpenSUSE metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,9 +12,10 @@ galaxy_info:
   - name: Fedora
     versions:
     - 25
-  - name: opensuse
-    versions:
-    - 42.2
+  # Galaxy doesn't support version 42.2 yet: "Invalid platform: opensuse-42.2 (skipping)"
+  # - name: opensuse
+  #   versions:
+  #   - 42.2
   - name: Ubuntu
     versions:
     - trusty


### PR DESCRIPTION
Ansible Galaxy doesn't support version 42.2 yet.