### PR TITLE
Changed example role to pure YAML syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Example Playbook
 ```yaml
 - hosts: servers
   roles:
-     - { role: gantsign.maven }
+    - role: gantsign.maven
 ```
 
 Role Facts


### PR DESCRIPTION
Using the hybrid YAML/JSON syntax is potentially confusing to new users as it's not clear whether this peculiar syntax is a requirement or not.