### PR TITLE
Added fact group name for multiple version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ maven_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.a
 # If this is the default installation, symbolic links to mvn and mvnDebug will
 # be created in /usr/local/bin
 maven_is_default_installation: yes
+
+# Name of the group of Ansible facts relating this Maven installation.
+#
+# Override if you want use this role more than once to install multiple versions
+# of Maven.
+#
+# e.g. maven_fact_group_name: maven_3_3
+# would change the Maven home fact to:
+# ansible_local.maven_3_2.general.home
+maven_fact_group_name: maven
 ```
 
 ### Supported Maven Versions
@@ -130,6 +140,23 @@ configuration will be required - see
       maven_version: '3.3.9'
 ```
 
+You can install the multiple versions of Maven by using this role more than
+once:
+
+```yaml
+- hosts: servers
+  roles:
+    - role: gantsign.maven
+      maven_version: '3.3.9'
+      maven_is_default_installation: yes
+      maven_fact_group_name: maven
+
+    - role: gantsign.maven
+      maven_version: '3.2.5'
+      maven_is_default_installation: no
+      maven_fact_group_name: maven_3_2
+```
+
 Role Facts
 ----------
 
@@ -142,6 +169,17 @@ This role exports the following Ansible facts for use by other roles:
 * `ansible_local.maven.general.home`
 
     * e.g. `/opt/maven/apache-maven-3.3.9`
+
+Overriding `maven_fact_group_name` will change the names of the facts e.g.:
+
+```yaml
+maven_fact_group_name: maven_3_2
+```
+
+Would change the name of the facts to:
+
+* `ansible_local.maven_3_2.general.version`
+* `ansible_local.maven_3_2.general.home`
 
 Related Roles
 -------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,13 @@ maven_download_dir: "{{ x_ansible_download_dir | default(ansible_env.HOME + '/.a
 # If this is the default installation, symbolic links to mvn and mvnDebug will
 # be created in /usr/local/bin
 maven_is_default_installation: yes
+
+# Name of the group of Ansible facts relating this Maven installation.
+#
+# Override if you want use this role more than once to install multiple versions
+# of Maven.
+#
+# e.g. maven_fact_group_name: maven_3_3
+# would change the Maven home fact to:
+# ansible_local.maven_3_2.general.home
+maven_fact_group_name: maven

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
   become: yes
   template:
     src: facts.j2
-    dest: /etc/ansible/facts.d/maven.fact
+    dest: '/etc/ansible/facts.d/{{ maven_fact_group_name }}.fact'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -60,9 +60,20 @@
       maven_version: '3.3.9'
       maven_install_dir: /opt/maven
 
+    - role: ansible-role-maven
+      maven_version: '3.2.5'
+      maven_is_default_installation: no
+      maven_fact_group_name: maven_3_2
+
   post_tasks:
-    - name: verify maven facts
+    - name: verify default maven facts
       assert:
         that:
           - ansible_local.maven.general.version is defined
           - ansible_local.maven.general.home is defined
+
+    - name: verify maven 3.2 facts
+      assert:
+        that:
+          - ansible_local.maven_3_2.general.version is defined
+          - ansible_local.maven_3_2.general.home is defined

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -13,15 +13,17 @@ def test_mvn_debug(Command):
     assert Command('which mvnDebug').rc == 0
 
 
-@pytest.mark.parametrize('command', [
-    'mvn',
-    'mvnDebug'
+@pytest.mark.parametrize('command,version_dir_pattern', [
+    ('mvn', 'apache-maven-3\\.3\\.[0-9]+$'),
+    ('mvnDebug', 'apache-maven-3\\.3\\.[0-9]+$'),
+    ('mvn', 'apache-maven-3\\.2\\.[0-9]+$'),
+    ('mvnDebug', 'apache-maven-3\\.2\\.[0-9]+$')
 ])
-def test_commands_installed(Command, File, command):
+def test_commands_installed(Command, File, command, version_dir_pattern):
 
     maven_home = Command.check_output('find %s | grep --color=never -E %s',
                                       '/opt/maven',
-                                      'apache-maven-3\\.3\\.[0-9]+$')
+                                      version_dir_pattern)
 
     command_file = File(maven_home + '/bin/' + command)
 
@@ -32,8 +34,12 @@ def test_commands_installed(Command, File, command):
     assert oct(command_file.mode) == '0755'
 
 
-def test_facts_installed(File):
-    fact_file = File('/etc/ansible/facts.d/maven.fact')
+@pytest.mark.parametrize('fact_group_name', [
+    'maven',
+    'maven_3_2'
+])
+def test_facts_installed(File, fact_group_name):
+    fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')
 
     assert fact_file.exists
     assert fact_file.is_file


### PR DESCRIPTION
To avoid overwriting the fact file and give you access to the facts for multiple Maven versions.