### PR TITLE
Updated Maven to 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Requirements
 
         | Maven Version | Minimum JDK Version |
         | ------------: | ------------------: |
+        |         3.5.x |                   7 |
         |         3.3.x |                   7 |
         |         3.2.x |                   6 |
         |         3.1.x |                   5 |
@@ -68,7 +69,7 @@ are shown below):
 
 ```yaml
 # Maven version number
-maven_version: '3.3.9'
+maven_version: '3.5.0'
 
 # Mirror to download the Maven redistributable package from
 maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex_replace('\\..*', '') }}/{{ maven_version }}/binaries"
@@ -100,6 +101,7 @@ The following versions of Maven are supported without any additional
 configuration (for other versions follow the Advanced Configuration
 instructions):
 
+* `3.5.0`
 * `3.3.9`
 * `3.2.5`
 * `3.1.1`
@@ -194,6 +196,8 @@ You may find the following related roles useful:
 
     * Installs the [Maven Color](https://github.com/jcgay/maven-color) extension
       for Maven authored by [Jean-Christophe Gay](https://github.com/jcgay).
+    * **Maven 3.5 has built in support color output**, so there's no need to
+      install this extension if using Maven 3.5.
 
 * [gantsign.maven-notifier](https://galaxy.ansible.com/gantsign/maven-notifier)
   for providing a GUI notification when a build ends.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Maven version number
-maven_version: '3.3.9'
+maven_version: '3.5.0'
 
 # Mirror to download the Maven redistributable package from
 maven_mirror: "http://archive.apache.org/dist/maven/maven-{{ maven_version|regex_replace('\\..*', '') }}/{{ maven_version }}/binaries"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -57,13 +57,13 @@
 
   roles:
     - role: ansible-role-maven
-      maven_version: '3.3.9'
+      maven_version: '3.5.0'
       maven_install_dir: /opt/maven
 
     - role: ansible-role-maven
-      maven_version: '3.2.5'
+      maven_version: '3.3.9'
       maven_is_default_installation: no
-      maven_fact_group_name: maven_3_2
+      maven_fact_group_name: maven_3_3
 
   post_tasks:
     - name: verify default maven facts
@@ -72,8 +72,8 @@
           - ansible_local.maven.general.version is defined
           - ansible_local.maven.general.home is defined
 
-    - name: verify maven 3.2 facts
+    - name: verify maven 3.3 facts
       assert:
         that:
-          - ansible_local.maven_3_2.general.version is defined
-          - ansible_local.maven_3_2.general.home is defined
+          - ansible_local.maven_3_3.general.version is defined
+          - ansible_local.maven_3_3.general.home is defined

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -6,7 +6,7 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 
 def test_mvn(Command):
-    assert '3.3.9' in Command.check_output('mvn --version')
+    assert '3.5.0' in Command.check_output('mvn --version')
 
 
 def test_mvn_debug(Command):
@@ -14,10 +14,10 @@ def test_mvn_debug(Command):
 
 
 @pytest.mark.parametrize('command,version_dir_pattern', [
+    ('mvn', 'apache-maven-3\\.5\\.[0-9]+$'),
+    ('mvnDebug', 'apache-maven-3\\.5\\.[0-9]+$'),
     ('mvn', 'apache-maven-3\\.3\\.[0-9]+$'),
-    ('mvnDebug', 'apache-maven-3\\.3\\.[0-9]+$'),
-    ('mvn', 'apache-maven-3\\.2\\.[0-9]+$'),
-    ('mvnDebug', 'apache-maven-3\\.2\\.[0-9]+$')
+    ('mvnDebug', 'apache-maven-3\\.3\\.[0-9]+$')
 ])
 def test_commands_installed(Command, File, command, version_dir_pattern):
 
@@ -36,7 +36,7 @@ def test_commands_installed(Command, File, command, version_dir_pattern):
 
 @pytest.mark.parametrize('fact_group_name', [
     'maven',
-    'maven_3_2'
+    'maven_3_3'
 ])
 def test_facts_installed(File, fact_group_name):
     fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')

--- a/vars/versions/3.5.0.yml
+++ b/vars/versions/3.5.0.yml
@@ -1,0 +1,3 @@
+---
+# SHA256 sum for the redistributable package
+maven_redis_sha256sum: 'beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034'


### PR DESCRIPTION
3.5.0 will now be installed by default.