### PR TITLE
Increased minimum Ansible version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,28 +7,28 @@ python: '2.7'
 matrix:
   include:
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=default
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=centos-min
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=centos-max
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=debian-min
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=debian-max
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=fedora
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=opensuse
     - env:
-        - ANSIBLE_VERSION=2.3.3
+        - ANSIBLE_VERSION=2.4.6
         - MOLECULE_SCENARIO=ubuntu-min
     - env:
         - ANSIBLE_VERSION=2.6.2

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Role to install the [Apache Maven](https://maven.apache.org) build tool.
 Requirements
 ------------
 
-* Ansible >= 2.3
+* Ansible >= 2.4
 
 * Linux Distribution
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role for installing Apache Maven.
   company: GantSign Ltd.
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
In preparation for resolving deprecated `include` warning.