### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,8 @@
     mode: 'go-w'
     creates: '{{ maven_install_dir }}/apache-maven-{{ maven_version }}'
 
-- include: create-symbolic-links.yml
+- name: create symbolic links
+  include_tasks: create-symbolic-links.yml
   when: maven_is_default_installation
 
 - name: create Ansible facts.d directory


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```