### PR TITLE
Changed tests to use host fixture

### DIFF
--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -7,12 +7,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_mvn(Command):
-    assert '3.5.4' in Command.check_output('mvn --version')
+def test_mvn(host):
+    assert '3.5.4' in host.check_output('mvn --version')
 
 
-def test_mvn_debug(Command):
-    assert Command('which mvnDebug').rc == 0
+def test_mvn_debug(host):
+    assert host.run('which mvnDebug').rc == 0
 
 
 @pytest.mark.parametrize('command,version_dir_pattern', [
@@ -21,13 +21,13 @@ def test_mvn_debug(Command):
     ('mvn', 'apache-maven-3\\.3\\.[0-9]+$'),
     ('mvnDebug', 'apache-maven-3\\.3\\.[0-9]+$')
 ])
-def test_commands_installed(Command, File, command, version_dir_pattern):
+def test_commands_installed(host, command, version_dir_pattern):
 
-    maven_home = Command.check_output('find %s | grep --color=never -E %s',
-                                      '/opt/maven',
-                                      version_dir_pattern)
+    maven_home = host.check_output('find %s | grep --color=never -E %s',
+                                   '/opt/maven',
+                                   version_dir_pattern)
 
-    command_file = File(maven_home + '/bin/' + command)
+    command_file = host.file(maven_home + '/bin/' + command)
 
     assert command_file.exists
     assert command_file.is_file
@@ -40,8 +40,8 @@ def test_commands_installed(Command, File, command, version_dir_pattern):
     'maven',
     'maven_3_3'
 ])
-def test_facts_installed(File, fact_group_name):
-    fact_file = File('/etc/ansible/facts.d/' + fact_group_name + '.fact')
+def test_facts_installed(host, fact_group_name):
+    fact_file = host.file('/etc/ansible/facts.d/' + fact_group_name + '.fact')
 
     assert fact_file.exists
     assert fact_file.is_file

--- a/molecule/single/tests/test_role.py
+++ b/molecule/single/tests/test_role.py
@@ -7,25 +7,25 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-def test_mvn(Command):
-    assert '3.5.4' in Command.check_output('mvn --version')
+def test_mvn(host):
+    assert '3.5.4' in host.check_output('mvn --version')
 
 
-def test_mvn_debug(Command):
-    assert Command('which mvnDebug').rc == 0
+def test_mvn_debug(host):
+    assert host.run('which mvnDebug').rc == 0
 
 
 @pytest.mark.parametrize('command,version_dir_pattern', [
     ('mvn', 'apache-maven-3\\.5\\.[0-9]+$'),
     ('mvnDebug', 'apache-maven-3\\.5\\.[0-9]+$')
 ])
-def test_commands_installed(Command, File, command, version_dir_pattern):
+def test_commands_installed(host, command, version_dir_pattern):
 
-    maven_home = Command.check_output('find %s | grep --color=never -E %s',
-                                      '/opt/maven',
-                                      version_dir_pattern)
+    maven_home = host.check_output('find %s | grep --color=never -E %s',
+                                   '/opt/maven',
+                                   version_dir_pattern)
 
-    command_file = File(maven_home + '/bin/' + command)
+    command_file = host.file(maven_home + '/bin/' + command)
 
     assert command_file.exists
     assert command_file.is_file
@@ -34,8 +34,8 @@ def test_commands_installed(Command, File, command, version_dir_pattern):
     assert oct(command_file.mode) == '0755'
 
 
-def test_facts_installed(File):
-    fact_file = File('/etc/ansible/facts.d/maven.fact')
+def test_facts_installed(host):
+    fact_file = host.file('/etc/ansible/facts.d/maven.fact')
 
     assert fact_file.exists
     assert fact_file.is_file


### PR DESCRIPTION
Other fixtures are deprecated and will be removed in 2.0 Testinfra release.