### PR TITLE
Fixed openSUSE support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
   with_items:
     - tar
     - unzip
+    - gzip
   when: ansible_pkg_mgr in ('dnf', 'zypper')
 
 - name: install Maven


### PR DESCRIPTION
You now need the `gzip` dependency as well as the `tar` dependency.