### PR TITLE
Replace deprecated sha256sum to checksum

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   get_url:
     url: '{{ maven_mirror }}/{{ maven_redis_filename }}'
     dest: '{{ maven_download_dir }}/{{ maven_redis_filename }}'
-    sha256sum: '{{ maven_redis_sha256sum }}'
+    checksum: 'sha256:{{ maven_redis_sha256sum }}'
     force: no
     use_proxy: yes
     validate_certs: yes


### PR DESCRIPTION
In order to fix

```
[DEPRECATION WARNING]: The parameter "sha256sum" has been deprecated and will 
be removed, use "checksum" instead. This feature will be removed from ansible-
base in version 2.14. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```