### PR TITLE
Dropped support for CentOS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Requirements
 
         * CentOS
 
-            * 6
             * 7
 
         * Fedora

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,6 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 6
         - 7
     - name: Fedora
       versions:

--- a/molecule/centos-min/molecule.yml
+++ b/molecule/centos-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-centos-min
-    image: centos:6
+    image: centos:7
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Maintenance updates for CentOS 6 ended on 2020-11-30.