### PR TITLE
Allow to override use_proxy and validate_certs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,7 @@ maven_is_default_installation: yes
 # would change the Maven home fact to:
 # ansible_local.maven_3_2.general.home
 maven_fact_group_name: maven
+
+maven_use_proxy: yes
+
+maven_validate_certs: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,8 +29,8 @@
     dest: '{{ maven_download_dir }}/{{ maven_redis_filename }}'
     checksum: 'sha256:{{ maven_redis_sha256sum }}'
     force: no
-    use_proxy: yes
-    validate_certs: yes
+    use_proxy: '{{ maven_use_proxy }}'
+    validate_certs: '{{ maven_validate_certs }}'
     timeout: '{{ maven_download_timeout }}'
     mode: 'u=rw,go=r'
 


### PR DESCRIPTION
Allow to override use_proxy and validate_certs

I need to disable proxy and certificats check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gantsign/ansible-role-maven/148)
<!-- Reviewable:end -->
