### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
             * Bullseye (11)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,7 +23,6 @@ galaxy_info:
     - name: Debian
       versions:
         - stretch
-        - jessie
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian-min/converge.yml
+++ b/molecule/debian-min/converge.yml
@@ -8,11 +8,10 @@
         update_cache: yes
       changed_when: no
 
-    # Travis CI doesn't provide all the Debian dependencies for the full JDK.
-    - name: install jre-headless 7
+    - name: install jre-headless 8
       become: yes
       apt:
-        name: openjdk-7-jre-headless
+        name: openjdk-8-jre-headless
         state: present
 
   roles:

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-debian-min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Debian ended LTS support in June 2020.