### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Requirements
 
             * Xenial (16.04)
             * Bionic (18.04)
-            * Focal (20.04)
 
     * RedHat Family
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - 15.1
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Debian

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.