### PR TITLE
Dropped support for Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Stretch (9)
             * Buster (10)
             * Bullseye (11)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,6 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
   galaxy_tags:

--- a/molecule/debian-min/molecule.yml
+++ b/molecule/debian-min/molecule.yml
@@ -15,7 +15,7 @@ lint: |
 
 platforms:
   - name: ansible-role-maven-debian-min
-    image: debian:9
+    image: debian:10
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Debian standard support ended on 01 Jul 2022.