### PR TITLE
Changed openSUSE tests to use Tumbleweed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requirements
 
         * openSUSE
 
-            * 15.2
+            * Tumbleweed
 
     * Note: other versions are likely to work but have not been tested.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
         - '34'
     - name: opensuse
       versions:
-        - '15.2'
+        - 'all'
     - name: Ubuntu
       versions:
         - focal

--- a/molecule/opensuse/molecule.yml
+++ b/molecule/opensuse/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-maven-opensuse
-    image: opensuse/leap:15.2
+    image: opensuse/tumbleweed
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Leap defaults to Python 3.6, which is too old for recent Ansible versions.