### PR TITLE
Dropped support for Ubuntu Focal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Ubuntu
 
-            * Focal (20.04)
             * Jammy (22.04)
             * Noble (24.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - 'all'
     - name: Ubuntu
       versions:
-        - focal
         - jammy
         - noble
     - name: Debian

--- a/molecule/ubuntu-min/molecule.yml
+++ b/molecule/ubuntu-min/molecule.yml
@@ -9,7 +9,7 @@ role_name_check: 2
 
 platforms:
   - name: ansible-role-maven-ubuntu-min
-    image: ubuntu:20.04
+    image: ubuntu:22.04
 
 provisioner:
   name: ansible


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Focal.